### PR TITLE
Fix viewing question on Moodle 4.x

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -43,6 +43,9 @@ class qtype_shortanssimilarity_renderer extends qtype_renderer {
 
         $question = $qa->get_question();
         $responseoutput = $question->get_format_renderer($this->page);
+        if (method_exists($responseoutput, 'set_displayoptions')) {
+            $responseoutput->set_displayoptions($options); // Moodle 4.x and later
+        }
 
         $step = $qa->get_last_step_with_qt_var('answer');
 


### PR DESCRIPTION
There was an exception when you're starting to view the question
`Exception - Call to a member function add_question_identifier_to_label() on null`
![moodle stacktrace](https://github.com/VIP-Research-Group/moodle-qtype_shortanssimilarity/assets/15987480/25d7fe4b-0bcf-47eb-927a-c0aa25b3fabc)

according to [this](https://github.com/gbateson/moodle-qtype_essayautograde/issues/69) I've fixed it
(It was from Moodle 4.x)